### PR TITLE
Update files to actually reflect 2.9.5 version

### DIFF
--- a/libxml2-export.c
+++ b/libxml2-export.c
@@ -166,9 +166,9 @@
     { (char *)"xmlAddDtdEntity", libxml_xmlAddDtdEntity, METH_VARARGS, NULL },
     { (char *)"xmlAddEncodingAlias", libxml_xmlAddEncodingAlias, METH_VARARGS, NULL },
     { (char *)"xmlAddNextSibling", libxml_xmlAddNextSibling, METH_VARARGS, NULL },
-#if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED)
+#if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_XINCLUDE_ENABLED)
     { (char *)"xmlAddPrevSibling", libxml_xmlAddPrevSibling, METH_VARARGS, NULL },
-#endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) */
+#endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_XINCLUDE_ENABLED) */
     { (char *)"xmlAddSibling", libxml_xmlAddSibling, METH_VARARGS, NULL },
 #if defined(LIBXML_DEBUG_ENABLED)
     { (char *)"xmlBoolToText", libxml_xmlBoolToText, METH_VARARGS, NULL },
@@ -1662,9 +1662,9 @@
 #if defined(LIBXML_VALID_ENABLED)
     { (char *)"xmlValidateElement", libxml_xmlValidateElement, METH_VARARGS, NULL },
 #endif /* defined(LIBXML_VALID_ENABLED) */
-#if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_XPATH_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_DEBUG_ENABLED) || defined (LIBXML_HTML_ENABLED) || defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_DOCB_ENABLED)
+#if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_XPATH_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_DEBUG_ENABLED) || defined (LIBXML_HTML_ENABLED) || defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_DOCB_ENABLED) || defined(LIBXML_LEGACY_ENABLED)
     { (char *)"xmlValidateNCName", libxml_xmlValidateNCName, METH_VARARGS, NULL },
-#endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_XPATH_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_DEBUG_ENABLED) || defined (LIBXML_HTML_ENABLED) || defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_DOCB_ENABLED) */
+#endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_XPATH_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_DEBUG_ENABLED) || defined (LIBXML_HTML_ENABLED) || defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_DOCB_ENABLED) || defined(LIBXML_LEGACY_ENABLED) */
 #if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED)
     { (char *)"xmlValidateNMToken", libxml_xmlValidateNMToken, METH_VARARGS, NULL },
 #endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) */

--- a/libxml2-py.c
+++ b/libxml2-py.c
@@ -1132,7 +1132,7 @@ libxml_xmlAddNextSibling(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     return(py_retval);
 }
 
-#if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED)
+#if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_XINCLUDE_ENABLED)
 PyObject *
 libxml_xmlAddPrevSibling(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
@@ -1152,7 +1152,7 @@ libxml_xmlAddPrevSibling(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     return(py_retval);
 }
 
-#endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) */
+#endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_XINCLUDE_ENABLED) */
 PyObject *
 libxml_xmlAddSibling(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
@@ -2429,12 +2429,12 @@ PyObject *
 libxml_xmlDocGetRootElement(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlNodePtr c_retval;
-    xmlDocPtr doc;
+    xmlDoc * doc;
     PyObject *pyobj_doc;
 
     if (!PyArg_ParseTuple(args, (char *)"O:xmlDocGetRootElement", &pyobj_doc))
         return(NULL);
-    doc = (xmlDocPtr) PyxmlNode_Get(pyobj_doc);
+    doc = (xmlDoc *) PyxmlNode_Get(pyobj_doc);
 
     c_retval = xmlDocGetRootElement(doc);
     py_retval = libxml_xmlNodePtrWrap((xmlNodePtr) c_retval);
@@ -2525,13 +2525,13 @@ PyObject *
 libxml_xmlEncodeSpecialChars(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlChar * c_retval;
-    xmlDocPtr doc;
+    xmlDoc * doc;
     PyObject *pyobj_doc;
     xmlChar * input;
 
     if (!PyArg_ParseTuple(args, (char *)"Oz:xmlEncodeSpecialChars", &pyobj_doc, &input))
         return(NULL);
-    doc = (xmlDocPtr) PyxmlNode_Get(pyobj_doc);
+    doc = (xmlDoc *) PyxmlNode_Get(pyobj_doc);
 
     c_retval = xmlEncodeSpecialChars(doc, input);
     py_retval = libxml_xmlCharPtrWrap((xmlChar *) c_retval);
@@ -2836,12 +2836,12 @@ PyObject *
 libxml_xmlGetDocCompressMode(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     int c_retval;
-    xmlDocPtr doc;
+    xmlDoc * doc;
     PyObject *pyobj_doc;
 
     if (!PyArg_ParseTuple(args, (char *)"O:xmlGetDocCompressMode", &pyobj_doc))
         return(NULL);
-    doc = (xmlDocPtr) PyxmlNode_Get(pyobj_doc);
+    doc = (xmlDoc *) PyxmlNode_Get(pyobj_doc);
 
     c_retval = xmlGetDocCompressMode(doc);
     py_retval = libxml_intWrap((int) c_retval);
@@ -2852,13 +2852,13 @@ PyObject *
 libxml_xmlGetDocEntity(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlEntityPtr c_retval;
-    xmlDocPtr doc;
+    xmlDoc * doc;
     PyObject *pyobj_doc;
     xmlChar * name;
 
     if (!PyArg_ParseTuple(args, (char *)"Oz:xmlGetDocEntity", &pyobj_doc, &name))
         return(NULL);
-    doc = (xmlDocPtr) PyxmlNode_Get(pyobj_doc);
+    doc = (xmlDoc *) PyxmlNode_Get(pyobj_doc);
 
     c_retval = xmlGetDocEntity(doc, name);
     py_retval = libxml_xmlNodePtrWrap((xmlNodePtr) c_retval);
@@ -2989,12 +2989,12 @@ PyObject *
 libxml_xmlGetIntSubset(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlDtdPtr c_retval;
-    xmlDocPtr doc;
+    xmlDoc * doc;
     PyObject *pyobj_doc;
 
     if (!PyArg_ParseTuple(args, (char *)"O:xmlGetIntSubset", &pyobj_doc))
         return(NULL);
-    doc = (xmlDocPtr) PyxmlNode_Get(pyobj_doc);
+    doc = (xmlDoc *) PyxmlNode_Get(pyobj_doc);
 
     c_retval = xmlGetIntSubset(doc);
     py_retval = libxml_xmlNodePtrWrap((xmlNodePtr) c_retval);
@@ -3005,12 +3005,12 @@ PyObject *
 libxml_xmlGetLastChild(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlNodePtr c_retval;
-    xmlNodePtr parent;
+    xmlNode * parent;
     PyObject *pyobj_parent;
 
     if (!PyArg_ParseTuple(args, (char *)"O:xmlGetLastChild", &pyobj_parent))
         return(NULL);
-    parent = (xmlNodePtr) PyxmlNode_Get(pyobj_parent);
+    parent = (xmlNode *) PyxmlNode_Get(pyobj_parent);
 
     c_retval = xmlGetLastChild(parent);
     py_retval = libxml_xmlNodePtrWrap((xmlNodePtr) c_retval);
@@ -3031,12 +3031,12 @@ PyObject *
 libxml_xmlGetLineNo(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     long c_retval;
-    xmlNodePtr node;
+    xmlNode * node;
     PyObject *pyobj_node;
 
     if (!PyArg_ParseTuple(args, (char *)"O:xmlGetLineNo", &pyobj_node))
         return(NULL);
-    node = (xmlNodePtr) PyxmlNode_Get(pyobj_node);
+    node = (xmlNode *) PyxmlNode_Get(pyobj_node);
 
     c_retval = xmlGetLineNo(node);
     py_retval = libxml_longWrap((long) c_retval);
@@ -3047,13 +3047,13 @@ PyObject *
 libxml_xmlGetNoNsProp(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlChar * c_retval;
-    xmlNodePtr node;
+    xmlNode * node;
     PyObject *pyobj_node;
     xmlChar * name;
 
     if (!PyArg_ParseTuple(args, (char *)"Oz:xmlGetNoNsProp", &pyobj_node, &name))
         return(NULL);
-    node = (xmlNodePtr) PyxmlNode_Get(pyobj_node);
+    node = (xmlNode *) PyxmlNode_Get(pyobj_node);
 
     c_retval = xmlGetNoNsProp(node, name);
     py_retval = libxml_xmlCharPtrWrap((xmlChar *) c_retval);
@@ -3065,12 +3065,12 @@ PyObject *
 libxml_xmlGetNodePath(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlChar * c_retval;
-    xmlNodePtr node;
+    xmlNode * node;
     PyObject *pyobj_node;
 
     if (!PyArg_ParseTuple(args, (char *)"O:xmlGetNodePath", &pyobj_node))
         return(NULL);
-    node = (xmlNodePtr) PyxmlNode_Get(pyobj_node);
+    node = (xmlNode *) PyxmlNode_Get(pyobj_node);
 
     c_retval = xmlGetNodePath(node);
     py_retval = libxml_xmlCharPtrWrap((xmlChar *) c_retval);
@@ -3082,14 +3082,14 @@ PyObject *
 libxml_xmlGetNsProp(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlChar * c_retval;
-    xmlNodePtr node;
+    xmlNode * node;
     PyObject *pyobj_node;
     xmlChar * name;
     xmlChar * nameSpace;
 
     if (!PyArg_ParseTuple(args, (char *)"Ozz:xmlGetNsProp", &pyobj_node, &name, &nameSpace))
         return(NULL);
-    node = (xmlNodePtr) PyxmlNode_Get(pyobj_node);
+    node = (xmlNode *) PyxmlNode_Get(pyobj_node);
 
     c_retval = xmlGetNsProp(node, name, nameSpace);
     py_retval = libxml_xmlCharPtrWrap((xmlChar *) c_retval);
@@ -3131,13 +3131,13 @@ PyObject *
 libxml_xmlGetProp(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlChar * c_retval;
-    xmlNodePtr node;
+    xmlNode * node;
     PyObject *pyobj_node;
     xmlChar * name;
 
     if (!PyArg_ParseTuple(args, (char *)"Oz:xmlGetProp", &pyobj_node, &name))
         return(NULL);
-    node = (xmlNodePtr) PyxmlNode_Get(pyobj_node);
+    node = (xmlNode *) PyxmlNode_Get(pyobj_node);
 
     c_retval = xmlGetProp(node, name);
     py_retval = libxml_xmlCharPtrWrap((xmlChar *) c_retval);
@@ -3167,14 +3167,14 @@ PyObject *
 libxml_xmlHasNsProp(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlAttrPtr c_retval;
-    xmlNodePtr node;
+    xmlNode * node;
     PyObject *pyobj_node;
     xmlChar * name;
     xmlChar * nameSpace;
 
     if (!PyArg_ParseTuple(args, (char *)"Ozz:xmlHasNsProp", &pyobj_node, &name, &nameSpace))
         return(NULL);
-    node = (xmlNodePtr) PyxmlNode_Get(pyobj_node);
+    node = (xmlNode *) PyxmlNode_Get(pyobj_node);
 
     c_retval = xmlHasNsProp(node, name, nameSpace);
     py_retval = libxml_xmlNodePtrWrap((xmlNodePtr) c_retval);
@@ -3185,13 +3185,13 @@ PyObject *
 libxml_xmlHasProp(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlAttrPtr c_retval;
-    xmlNodePtr node;
+    xmlNode * node;
     PyObject *pyobj_node;
     xmlChar * name;
 
     if (!PyArg_ParseTuple(args, (char *)"Oz:xmlHasProp", &pyobj_node, &name))
         return(NULL);
-    node = (xmlNodePtr) PyxmlNode_Get(pyobj_node);
+    node = (xmlNode *) PyxmlNode_Get(pyobj_node);
 
     c_retval = xmlHasProp(node, name);
     py_retval = libxml_xmlNodePtrWrap((xmlNodePtr) c_retval);
@@ -3332,12 +3332,12 @@ PyObject *
 libxml_xmlIsBlankNode(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     int c_retval;
-    xmlNodePtr node;
+    xmlNode * node;
     PyObject *pyobj_node;
 
     if (!PyArg_ParseTuple(args, (char *)"O:xmlIsBlankNode", &pyobj_node))
         return(NULL);
-    node = (xmlNodePtr) PyxmlNode_Get(pyobj_node);
+    node = (xmlNode *) PyxmlNode_Get(pyobj_node);
 
     c_retval = xmlIsBlankNode(node);
     py_retval = libxml_intWrap((int) c_retval);
@@ -4028,13 +4028,13 @@ PyObject *
 libxml_xmlNewDocText(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlNodePtr c_retval;
-    xmlDocPtr doc;
+    xmlDoc * doc;
     PyObject *pyobj_doc;
     xmlChar * content;
 
     if (!PyArg_ParseTuple(args, (char *)"Oz:xmlNewDocText", &pyobj_doc, &content))
         return(NULL);
-    doc = (xmlDocPtr) PyxmlNode_Get(pyobj_doc);
+    doc = (xmlDoc *) PyxmlNode_Get(pyobj_doc);
 
     c_retval = xmlNewDocText(doc, content);
     py_retval = libxml_xmlNodePtrWrap((xmlNodePtr) c_retval);
@@ -4245,13 +4245,13 @@ PyObject *
 libxml_xmlNewReference(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlNodePtr c_retval;
-    xmlDocPtr doc;
+    xmlDoc * doc;
     PyObject *pyobj_doc;
     xmlChar * name;
 
     if (!PyArg_ParseTuple(args, (char *)"Oz:xmlNewReference", &pyobj_doc, &name))
         return(NULL);
-    doc = (xmlDocPtr) PyxmlNode_Get(pyobj_doc);
+    doc = (xmlDoc *) PyxmlNode_Get(pyobj_doc);
 
     c_retval = xmlNewReference(doc, name);
     py_retval = libxml_xmlNodePtrWrap((xmlNodePtr) c_retval);
@@ -4449,15 +4449,15 @@ PyObject *
 libxml_xmlNodeGetBase(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlChar * c_retval;
-    xmlDocPtr doc;
+    xmlDoc * doc;
     PyObject *pyobj_doc;
-    xmlNodePtr cur;
+    xmlNode * cur;
     PyObject *pyobj_cur;
 
     if (!PyArg_ParseTuple(args, (char *)"OO:xmlNodeGetBase", &pyobj_doc, &pyobj_cur))
         return(NULL);
-    doc = (xmlDocPtr) PyxmlNode_Get(pyobj_doc);
-    cur = (xmlNodePtr) PyxmlNode_Get(pyobj_cur);
+    doc = (xmlDoc *) PyxmlNode_Get(pyobj_doc);
+    cur = (xmlNode *) PyxmlNode_Get(pyobj_cur);
 
     c_retval = xmlNodeGetBase(doc, cur);
     py_retval = libxml_xmlCharPtrWrap((xmlChar *) c_retval);
@@ -4468,12 +4468,12 @@ PyObject *
 libxml_xmlNodeGetContent(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlChar * c_retval;
-    xmlNodePtr cur;
+    xmlNode * cur;
     PyObject *pyobj_cur;
 
     if (!PyArg_ParseTuple(args, (char *)"O:xmlNodeGetContent", &pyobj_cur))
         return(NULL);
-    cur = (xmlNodePtr) PyxmlNode_Get(pyobj_cur);
+    cur = (xmlNode *) PyxmlNode_Get(pyobj_cur);
 
     c_retval = xmlNodeGetContent(cur);
     py_retval = libxml_xmlCharPtrWrap((xmlChar *) c_retval);
@@ -4484,12 +4484,12 @@ PyObject *
 libxml_xmlNodeGetLang(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlChar * c_retval;
-    xmlNodePtr cur;
+    xmlNode * cur;
     PyObject *pyobj_cur;
 
     if (!PyArg_ParseTuple(args, (char *)"O:xmlNodeGetLang", &pyobj_cur))
         return(NULL);
-    cur = (xmlNodePtr) PyxmlNode_Get(pyobj_cur);
+    cur = (xmlNode *) PyxmlNode_Get(pyobj_cur);
 
     c_retval = xmlNodeGetLang(cur);
     py_retval = libxml_xmlCharPtrWrap((xmlChar *) c_retval);
@@ -4500,12 +4500,12 @@ PyObject *
 libxml_xmlNodeGetSpacePreserve(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     int c_retval;
-    xmlNodePtr cur;
+    xmlNode * cur;
     PyObject *pyobj_cur;
 
     if (!PyArg_ParseTuple(args, (char *)"O:xmlNodeGetSpacePreserve", &pyobj_cur))
         return(NULL);
-    cur = (xmlNodePtr) PyxmlNode_Get(pyobj_cur);
+    cur = (xmlNode *) PyxmlNode_Get(pyobj_cur);
 
     c_retval = xmlNodeGetSpacePreserve(cur);
     py_retval = libxml_intWrap((int) c_retval);
@@ -4516,12 +4516,12 @@ PyObject *
 libxml_xmlNodeIsText(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     int c_retval;
-    xmlNodePtr node;
+    xmlNode * node;
     PyObject *pyobj_node;
 
     if (!PyArg_ParseTuple(args, (char *)"O:xmlNodeIsText", &pyobj_node))
         return(NULL);
-    node = (xmlNodePtr) PyxmlNode_Get(pyobj_node);
+    node = (xmlNode *) PyxmlNode_Get(pyobj_node);
 
     c_retval = xmlNodeIsText(node);
     py_retval = libxml_intWrap((int) c_retval);
@@ -4533,16 +4533,16 @@ PyObject *
 libxml_xmlNodeListGetRawString(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlChar * c_retval;
-    xmlDocPtr doc;
+    xmlDoc * doc;
     PyObject *pyobj_doc;
-    xmlNodePtr list;
+    xmlNode * list;
     PyObject *pyobj_list;
     int inLine;
 
     if (!PyArg_ParseTuple(args, (char *)"OOi:xmlNodeListGetRawString", &pyobj_doc, &pyobj_list, &inLine))
         return(NULL);
-    doc = (xmlDocPtr) PyxmlNode_Get(pyobj_doc);
-    list = (xmlNodePtr) PyxmlNode_Get(pyobj_list);
+    doc = (xmlDoc *) PyxmlNode_Get(pyobj_doc);
+    list = (xmlNode *) PyxmlNode_Get(pyobj_list);
 
     c_retval = xmlNodeListGetRawString(doc, list, inLine);
     py_retval = libxml_xmlCharPtrWrap((xmlChar *) c_retval);
@@ -4556,14 +4556,14 @@ libxml_xmlNodeListGetString(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     xmlChar * c_retval;
     xmlDocPtr doc;
     PyObject *pyobj_doc;
-    xmlNodePtr list;
+    xmlNode * list;
     PyObject *pyobj_list;
     int inLine;
 
     if (!PyArg_ParseTuple(args, (char *)"OOi:xmlNodeListGetString", &pyobj_doc, &pyobj_list, &inLine))
         return(NULL);
     doc = (xmlDocPtr) PyxmlNode_Get(pyobj_doc);
-    list = (xmlNodePtr) PyxmlNode_Get(pyobj_list);
+    list = (xmlNode *) PyxmlNode_Get(pyobj_list);
 
     c_retval = xmlNodeListGetString(doc, list, inLine);
     py_retval = libxml_xmlCharPtrWrap((xmlChar *) c_retval);
@@ -7517,13 +7517,13 @@ PyObject *
 libxml_xmlStringGetNodeList(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlNodePtr c_retval;
-    xmlDocPtr doc;
+    xmlDoc * doc;
     PyObject *pyobj_doc;
     xmlChar * value;
 
     if (!PyArg_ParseTuple(args, (char *)"Oz:xmlStringGetNodeList", &pyobj_doc, &value))
         return(NULL);
-    doc = (xmlDocPtr) PyxmlNode_Get(pyobj_doc);
+    doc = (xmlDoc *) PyxmlNode_Get(pyobj_doc);
 
     c_retval = xmlStringGetNodeList(doc, value);
     py_retval = libxml_xmlNodePtrWrap((xmlNodePtr) c_retval);
@@ -7556,14 +7556,14 @@ PyObject *
 libxml_xmlStringLenGetNodeList(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
     xmlNodePtr c_retval;
-    xmlDocPtr doc;
+    xmlDoc * doc;
     PyObject *pyobj_doc;
     xmlChar * value;
     int len;
 
     if (!PyArg_ParseTuple(args, (char *)"Ozi:xmlStringLenGetNodeList", &pyobj_doc, &value, &len))
         return(NULL);
-    doc = (xmlDocPtr) PyxmlNode_Get(pyobj_doc);
+    doc = (xmlDoc *) PyxmlNode_Get(pyobj_doc);
 
     c_retval = xmlStringLenGetNodeList(doc, value, len);
     py_retval = libxml_xmlNodePtrWrap((xmlNodePtr) c_retval);
@@ -12384,7 +12384,7 @@ libxml_xmlValidateElement(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
 }
 
 #endif /* defined(LIBXML_VALID_ENABLED) */
-#if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_XPATH_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_DEBUG_ENABLED) || defined (LIBXML_HTML_ENABLED) || defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_DOCB_ENABLED)
+#if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_XPATH_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_DEBUG_ENABLED) || defined (LIBXML_HTML_ENABLED) || defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_DOCB_ENABLED) || defined(LIBXML_LEGACY_ENABLED)
 PyObject *
 libxml_xmlValidateNCName(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     PyObject *py_retval;
@@ -12400,7 +12400,7 @@ libxml_xmlValidateNCName(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {
     return(py_retval);
 }
 
-#endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_XPATH_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_DEBUG_ENABLED) || defined (LIBXML_HTML_ENABLED) || defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_DOCB_ENABLED) */
+#endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_XPATH_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_DEBUG_ENABLED) || defined (LIBXML_HTML_ENABLED) || defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_DOCB_ENABLED) || defined(LIBXML_LEGACY_ENABLED) */
 #if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED)
 PyObject *
 libxml_xmlValidateNMToken(PyObject *self ATTRIBUTE_UNUSED, PyObject *args) {

--- a/libxml2-py.h
+++ b/libxml2-py.h
@@ -166,9 +166,9 @@ PyObject * libxml_xmlAddDocEntity(PyObject *self, PyObject *args);
 PyObject * libxml_xmlAddDtdEntity(PyObject *self, PyObject *args);
 PyObject * libxml_xmlAddEncodingAlias(PyObject *self, PyObject *args);
 PyObject * libxml_xmlAddNextSibling(PyObject *self, PyObject *args);
-#if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED)
+#if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_XINCLUDE_ENABLED)
 PyObject * libxml_xmlAddPrevSibling(PyObject *self, PyObject *args);
-#endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) */
+#endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_XINCLUDE_ENABLED) */
 PyObject * libxml_xmlAddSibling(PyObject *self, PyObject *args);
 #if defined(LIBXML_DEBUG_ENABLED)
 PyObject * libxml_xmlBoolToText(PyObject *self, PyObject *args);
@@ -1662,9 +1662,9 @@ PyObject * libxml_xmlValidateDtdFinal(PyObject *self, PyObject *args);
 #if defined(LIBXML_VALID_ENABLED)
 PyObject * libxml_xmlValidateElement(PyObject *self, PyObject *args);
 #endif /* defined(LIBXML_VALID_ENABLED) */
-#if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_XPATH_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_DEBUG_ENABLED) || defined (LIBXML_HTML_ENABLED) || defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_DOCB_ENABLED)
+#if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_XPATH_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_DEBUG_ENABLED) || defined (LIBXML_HTML_ENABLED) || defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_DOCB_ENABLED) || defined(LIBXML_LEGACY_ENABLED)
 PyObject * libxml_xmlValidateNCName(PyObject *self, PyObject *args);
-#endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_XPATH_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_DEBUG_ENABLED) || defined (LIBXML_HTML_ENABLED) || defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_DOCB_ENABLED) */
+#endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_XPATH_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) || defined(LIBXML_DEBUG_ENABLED) || defined (LIBXML_HTML_ENABLED) || defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_DOCB_ENABLED) || defined(LIBXML_LEGACY_ENABLED) */
 #if defined(LIBXML_TREE_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED)
 PyObject * libxml_xmlValidateNMToken(PyObject *self, PyObject *args);
 #endif /* defined(LIBXML_TREE_ENABLED) || defined(LIBXML_SCHEMAS_ENABLED) */

--- a/libxml2.py
+++ b/libxml2.py
@@ -530,7 +530,7 @@ class xmlCoreDepthFirstItertor:
         self.parents = []
     def __iter__(self):
         return self
-    def next(self):
+    def __next__(self):
         while 1:
             if self.node:
                 ret = self.node
@@ -542,6 +542,7 @@ class xmlCoreDepthFirstItertor:
             except IndexError:
                 raise StopIteration
             self.node = parent.next
+    next = __next__
 
 #
 # implements the breadth-first iterator for libxml2 DOM tree
@@ -552,7 +553,7 @@ class xmlCoreBreadthFirstItertor:
         self.parents = []
     def __iter__(self):
         return self
-    def next(self):
+    def __next__(self):
         while 1:
             if self.node:
                 ret = self.node
@@ -564,6 +565,7 @@ class xmlCoreBreadthFirstItertor:
             except IndexError:
                 raise StopIteration
             self.node = parent.children
+    next = __next__
 
 #
 # converters to present a nicer view of the XPath returns
@@ -2065,7 +2067,7 @@ def UTF8Strpos(utf, pos):
 
 def UTF8Strsize(utf, len):
     """storage size of an UTF8 string the behaviour is not
-       garanteed if the input string is not UTF-8 """
+       guaranteed if the input string is not UTF-8 """
     ret = libxml2mod.xmlUTF8Strsize(utf, len)
     return ret
 
@@ -3363,8 +3365,10 @@ class xmlNode(xmlCore):
     def newNs(self, href, prefix):
         """Creation of a new Namespace. This function will refuse to
           create a namespace with a similar prefix than an existing
-          one present on this node. We use href==None in the case of
-           an element creation where the namespace was not defined. """
+          one present on this node. Note that for a default
+          namespace, @prefix should be None.  We use href==None in
+          the case of an element creation where the namespace was not
+           defined. """
         ret = libxml2mod.xmlNewNs(self._o, href, prefix)
         if ret is None:raise treeError('xmlNewNs() failed')
         __tmp = xmlNs(_obj=ret)
@@ -7337,7 +7341,7 @@ class xpathContext:
         return xpathObjectRet(ret)
 
     def xpathEvalExpression(self, str):
-        """Evaluate the XPath expression in the given context. """
+        """Alias for xmlXPathEval(). """
         ret = libxml2mod.xmlXPathEvalExpression(str, self._o)
         if ret is None:raise xpathError('xmlXPathEvalExpression() failed')
         return xpathObjectRet(ret)
@@ -7828,7 +7832,8 @@ class xpathParserContext:
         """Implement the round() XPath function number round(number)
           The round function returns the number that is closest to
           the argument and that is an integer. If there are two such
-           numbers, then the one that is even is returned. """
+          numbers, then the one that is closest to positive infinity
+           is returned. """
         libxml2mod.xmlXPathRoundFunction(self._o, nargs)
 
     def xpathStartsWithFunction(self, nargs):
@@ -7982,7 +7987,9 @@ class xpathParserContext:
         libxml2mod.xmlXPtrEvalRangePredicate(self._o)
 
     def xpointerRangeToFunction(self, nargs):
-        """Implement the range-to() XPointer function """
+        """Implement the range-to() XPointer function  Obsolete.
+          range-to is not a real function but a special type of
+           location step which is handled in xpath.c. """
         libxml2mod.xmlXPtrRangeToFunction(self._o, nargs)
 
 # xlinkShow
@@ -8002,6 +8009,7 @@ XML_BUFFER_ALLOC_EXACT = 2
 XML_BUFFER_ALLOC_IMMUTABLE = 3
 XML_BUFFER_ALLOC_IO = 4
 XML_BUFFER_ALLOC_HYBRID = 5
+XML_BUFFER_ALLOC_BOUNDED = 6
 
 # xmlParserSeverities
 XML_PARSER_SEVERITY_VALIDITY_WARNING = 1

--- a/libxml2class.py
+++ b/libxml2class.py
@@ -1279,7 +1279,7 @@ def UTF8Strpos(utf, pos):
 
 def UTF8Strsize(utf, len):
     """storage size of an UTF8 string the behaviour is not
-       garanteed if the input string is not UTF-8 """
+       guaranteed if the input string is not UTF-8 """
     ret = libxml2mod.xmlUTF8Strsize(utf, len)
     return ret
 
@@ -2577,8 +2577,10 @@ class xmlNode(xmlCore):
     def newNs(self, href, prefix):
         """Creation of a new Namespace. This function will refuse to
           create a namespace with a similar prefix than an existing
-          one present on this node. We use href==None in the case of
-           an element creation where the namespace was not defined. """
+          one present on this node. Note that for a default
+          namespace, @prefix should be None.  We use href==None in
+          the case of an element creation where the namespace was not
+           defined. """
         ret = libxml2mod.xmlNewNs(self._o, href, prefix)
         if ret is None:raise treeError('xmlNewNs() failed')
         __tmp = xmlNs(_obj=ret)
@@ -6551,7 +6553,7 @@ class xpathContext:
         return xpathObjectRet(ret)
 
     def xpathEvalExpression(self, str):
-        """Evaluate the XPath expression in the given context. """
+        """Alias for xmlXPathEval(). """
         ret = libxml2mod.xmlXPathEvalExpression(str, self._o)
         if ret is None:raise xpathError('xmlXPathEvalExpression() failed')
         return xpathObjectRet(ret)
@@ -7042,7 +7044,8 @@ class xpathParserContext:
         """Implement the round() XPath function number round(number)
           The round function returns the number that is closest to
           the argument and that is an integer. If there are two such
-           numbers, then the one that is even is returned. """
+          numbers, then the one that is closest to positive infinity
+           is returned. """
         libxml2mod.xmlXPathRoundFunction(self._o, nargs)
 
     def xpathStartsWithFunction(self, nargs):
@@ -7196,7 +7199,9 @@ class xpathParserContext:
         libxml2mod.xmlXPtrEvalRangePredicate(self._o)
 
     def xpointerRangeToFunction(self, nargs):
-        """Implement the range-to() XPointer function """
+        """Implement the range-to() XPointer function  Obsolete.
+          range-to is not a real function but a special type of
+           location step which is handled in xpath.c. """
         libxml2mod.xmlXPtrRangeToFunction(self._o, nargs)
 
 # xlinkShow
@@ -7216,6 +7221,7 @@ XML_BUFFER_ALLOC_EXACT = 2
 XML_BUFFER_ALLOC_IMMUTABLE = 3
 XML_BUFFER_ALLOC_IO = 4
 XML_BUFFER_ALLOC_HYBRID = 5
+XML_BUFFER_ALLOC_BOUNDED = 6
 
 # xmlParserSeverities
 XML_PARSER_SEVERITY_VALIDITY_WARNING = 1

--- a/types.c
+++ b/types.c
@@ -31,6 +31,8 @@ libxml_PyFileGet(PyObject *f) {
     const char *mode;
 
     fd = PyObject_AsFileDescriptor(f);
+    if (!_PyVerify_fd(fd))
+        return(NULL);
     /*
      * Get the flags on the fd to understand how it was opened
      */


### PR DESCRIPTION
There is an issue while using virt-manager with libxml2-python3
installed by pip:

Traceback (most recent call last):
  File "/usr/share/virt-manager/virtManager/details.py", line 1857, in remove_device
    self.vm.remove_device(devobj)
  File "/usr/share/virt-manager/virtManager/domain.py", line 452, in remove_device
    xmlobj.remove_device(editdev)
  File "/usr/share/virt-manager/virtinst/guest.py", line 438, in remove_device
    self.devices.remove_child(dev)
  File "/usr/share/virt-manager/virtinst/xmlbuilder.py", line 709, in remove_child
    self._xmlstate.xmlapi.node_force_remove(xpath)
  File "/usr/share/virt-manager/virtinst/xmlapi.py", line 174, in node_force_remove
    self._node_remove_child(parentnode, childnode)
  File "/usr/share/virt-manager/virtinst/xmlapi.py", line 375, in _node_remove_child
    if all([node_is_text(n) for n in parentnode.children]):
TypeError: iter() returned non-iterator of type 'xmlCoreDepthFirstItertor'

The error is caused by missing __next__ method in that Class and it's
because the libxml2.py file is for some reason different then the
libxml.py file.

Signed-off-by: Pavel Hrdina <phrdina@redhat.com>